### PR TITLE
NAS-124714 / 24.10 / initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+cryptit
+======
+
+**Python bindings to the crypt_r syscall**
+
+**QUICK HOWTO:**
+
+Generate a SHA512 hashed password, with rounds set to 656,000 using a
+cryptographically secure 16 char salt using the modular crypt format
+found on most *nix based systems.
+```
+from secrets import token_hex
+from cryptit import cryptit
+
+>>> SHA512_PREFIX = '$6'
+>>> rounds = 656_000
+>>> salt = token_hex()[:16]
+>>> passwd = 'your password'
+>>> settings = f'{SHA512_PREFIX}$rounds={rounds}${salt}'
+>>> hash = cryptit(passwd, settings)
+>>> hash
+'$6$rounds=656000$215bf4d450b99d32$W0MeOWckrgYhSKVpRFuxMtWm7OUGblzH91HAOyJMeGB7aitE4w/5trbfX9aI7P5GukcQlcihOEv3qfTfzP5V//'
+>>>
+```
+
+Generating a secure hash is 50% of the problem. One must verify the password
+to make sure it is correct. Using the `hash` from the above example, this
+demonstrates how to securely verify if the password is correct against a given
+`user_hash`
+```
+from secrets import compare_digest
+from cryptit import cryptit
+
+>>> passwd = 'your password'
+>>> hash = '$6$rounds=656000$215bf4d450b99d32$W0MeOWckrgYhSKVpRFuxMtWm7OUGblzH91HAOyJMeGB7aitE4w/5trbfX9aI7P5GukcQlcihOEv3qfTfzP5V//'
+>>> user_hash = hash
+# the `user_hash` variable is expected to be found/provided/given
+# to this function by whatever means necessary (stored in a db, from shadow file, etc)
+>>> compare_digest(cryptit(passwd, hash), user_hash)
+True  # means the password matches
+
+# given the same example, if we were to scramble the `user_hash` to ensure the validation
+# fails it would look like this
+user_hash = 'does not match'
+>>> compare_digest(cryptit(passwd, hash), user_hash)
+False
+```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+py-cryptit (1.0.0~truenas+0) unstable; urgency=medium
+
+  * Initial release
+
+ -- Andrew Walker <awalker@ixsystems.com>  Wed, 7 Feb 2024 14:10:00 -0500

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ py-cryptit (1.0.0~truenas+0) unstable; urgency=medium
 
   * Initial release
 
- -- Andrew Walker <awalker@ixsystems.com>  Wed, 7 Feb 2024 14:10:00 -0500
+ -- Caleb St. John <caleb@ixsystems.com>  Wed, 7 Feb 2024 14:10:00 -0500

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,20 @@
+Source: cryptit
+Section: contrib/python
+Priority: optional
+Maintainer: Caleb St. John <caleb@ixsystems.com>
+Build-Depends: debhelper-compat (= 12),
+               dh-python,
+			   libcrypt-dev,
+               python3-all-dev,
+               python3-setuptools
+Standards-Version: 4.4.1
+Homepage: https://github.com/truenas/py-cryptit
+
+Package: python3-cryptit
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}
+Description: Python crypt binding
+ cryptit is a straight-forward set of Python
+ bindings for the crypt syscall on Debian linux.
+ .
+ This package installs the library for Python 3.

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: cryptit
+Source: py-cryptit
 Section: contrib/python
 Priority: optional
 Maintainer: Caleb St. John <caleb@ixsystems.com>

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: py-cryptit
+Source: https://github.com/truenas/py-cryptit
+Comment: Build-depends on package in contrib
+
+Files: *
+Copyright: 2024 Caleb St. John <caleb@ixsystems.com>
+License: LGPL-3.0+

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,14 @@
+#!/usr/bin/make -f
+#export DH_VERBOSE = 1
+
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export PYBUILD_NAME=cryptit
+
+%:
+	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_auto_configure:
+	dh_auto_configure
+
+override_dh_install:
+	dh_install

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import Extension, setup
+
+setup(
+    name='cryptit',
+    version='1.0.0',
+    ext_modules=[
+        Extension(
+            name='cryptit',
+            sources=['src/cryptit.c'],
+            libraries=['crypt']
+        )
+    ]
+)

--- a/src/cryptit.c
+++ b/src/cryptit.c
@@ -1,0 +1,108 @@
+#define PY_SSIZE_T_CLEAN
+#include <python3.11/Python.h>
+#include <stdio.h>
+#include <crypt.h>
+
+// most of this code is copy and pasted from
+// https://github.com/python/cpython/blob/3.11/Modules/clinic/_cryptmodule.c.h
+// with the exception of what methods are named as to
+// not cause a module naming conflict since the "crypt"
+// module hasn't been removed (yet, python3.13)
+PyDoc_STRVAR(cryptit__doc__,
+"cryptit($module, word, salt, /)\n"
+"--\n"
+"\n"
+"Hash a *word* with the given *salt* and return the hashed password.\n"
+"\n"
+"*word* will usually be a user\'s password.  *salt* (either a random 2 or 16\n"
+"character string, possibly prefixed with $digit$ to indicate the method)\n"
+"will be used to perturb the encryption algorithm and produce distinct\n"
+"results for a given *word*.");
+
+
+static PyObject *
+cryptit_impl(PyObject *self, const char *word, const char *salt)
+{
+    char *hash;
+    struct crypt_data data;
+    Py_BEGIN_ALLOW_THREADS
+    // depending on the prefix of the salt (sha256/512)
+    // and the rounds (if specified), this could take
+    // considerable amounts of time so drop the GIL
+    memset(&data, 0, sizeof(data));
+    hash = crypt_r(word, salt, &data);
+    Py_END_ALLOW_THREADS
+    if (hash == NULL)
+        return PyErr_SetFromErrno(PyExc_OSError);
+    return Py_BuildValue("s", hash);
+}
+
+
+static PyObject *
+method_cryptit(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    const char *word;
+    const char *salt;
+
+    if (!_PyArg_CheckPositional("method_cryptit", nargs, 2, 2))
+        goto exit;
+    if (!PyUnicode_Check(args[0])) {
+        _PyArg_BadArgument("method_cryptit", "argument 1", "str", args[0]);
+        goto exit;
+    }
+    Py_ssize_t word_length;
+    word = PyUnicode_AsUTF8AndSize(args[0], &word_length);
+    if (word == NULL)
+        goto exit;
+    if (strlen(word) != (size_t)word_length) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        goto exit;
+    }
+    if (!PyUnicode_Check(args[1])) {
+        _PyArg_BadArgument("method_cryptit", "argument 2", "str", args[1]);
+        goto exit;
+    }
+    Py_ssize_t salt_length;
+    salt = PyUnicode_AsUTF8AndSize(args[1], &salt_length);
+    if (salt == NULL)
+        goto exit;
+    if (strlen(salt) != (size_t)salt_length) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        goto exit;
+    }
+	return_value = cryptit_impl(self, word, salt);
+
+exit:
+    return return_value;
+}
+
+
+static PyMethodDef cryptitmethods[] = {
+    {"cryptit", _PyCFunction_CAST(method_cryptit), METH_FASTCALL, cryptit__doc__},
+    {NULL, NULL, 0, NULL}
+};
+
+
+static PyModuleDef_Slot _cryptit_slots[] = {
+    {0, NULL}
+};
+
+
+static struct PyModuleDef cryptitmodule = {
+    PyModuleDef_HEAD_INIT,
+    "_cryptit",
+    NULL,
+    0,
+    cryptitmethods,
+    _cryptit_slots,
+    NULL,
+    NULL,
+    NULL
+};
+
+
+PyMODINIT_FUNC PyInit_cryptit(void)
+{
+    return PyModuleDef_Init(&cryptitmodule);
+}

--- a/src/cryptit.c
+++ b/src/cryptit.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <python3.11/Python.h>
+#include <Python.h>
 #include <stdio.h>
 #include <crypt.h>
 


### PR DESCRIPTION
This adds python C bindings for the `crypt_r` syscall. Python 3.13 will be removing the included `crypt` module and does not have a replacement. Instead of pulling in another 3rd party dependency and because the OS provides an API that is very straight-forward to use, we'll provide our own package to do this. https://peps.python.org/pep-0594/#crypt

This should be a drop-in replacement for the builtin `crypt` module.